### PR TITLE
Fixing issues identified in issue #14

### DIFF
--- a/_episodes/04-undo.md
+++ b/_episodes/04-undo.md
@@ -18,13 +18,50 @@ keypoints:
 
 ---
 
+## Exercise: Creating a branch.
+
+> - Create a new branch called `hotfix`. Create a new file and make 3-4 commits in that file or create 3-4 new files. Check the log to see the SHA of the last commit.
+> 
+> > ## Solution
+> > ~~~
+> > git checkout -b hotfix
+> > touch a.txt
+> > git add . && git commit -m "1st git commit: 1 file"
+> > touch b.txt
+> > git add . && git commit -m "2nd git commit: 2 file"
+> > touch c.txt
+> > git add . && git commit -m "3rd git commit: 3 file"
+> > git status
+> > git log --oneline 
+> > ~~~
+> > {: .language-bash}
+> {: .solution}
+{: .challenge}
+
+
+## Git Revert
+
+Reverting undoes a commit by creating a new commit. This is a safe way to undo changes, as it has no chance of re-writing the commit history. For example, the following command will figure out the changes contained in the 2nd to last commit, create a new commit undoing those changes, and tack the new commit onto the existing project.
+
+~~~
+git revert HEAD~1
+ls
+~~~
+{: .language-bash}
+
+![GitFlow 1](../fig/08-revert.png)
+
+Note that revert only backs out the atomic changes of the ONE specific commit (by default, you can also give it a range of commits but we are not going to do that here, see the help).
+
+`git revert` does not rewrite history which is why it is the preferred way of dealing with issues when the changes have already been pushed to a remote repository.
+
 ## Git Reset
 
 Resetting is a way to move the tip of a branch to a different commit. This can be used to remove commits from the current branch. For example, the following command moves the `hotfix` branch backwards by two commits.
 
 ~~~
 git checkout hotfix
-git reset HEAD~2
+git reset HEAD~1
 ~~~
 {: .language-bash}
 
@@ -32,6 +69,14 @@ git reset HEAD~2
 
 
 The two commits that were on the end of `hotfix` are now dangling, or orphaned commits. This means they will be deleted the next time `git` performs a garbage collection. In other words, you’re saying that you want to throw away these commits.
+
+`git reset` also reverts the commits but leaves the uncommitted changes in the repo.
+
+~~~
+git status
+git restore b.txt
+~~~
+{: .language-bash}
 
 `git reset` is a simple way to undo changes that haven’t been shared with anyone else. It’s your go-to command when you’ve started working on a feature and find yourself thinking, “Oh crap, what am I doing? I should just start over.”
 
@@ -48,9 +93,15 @@ It’s easier to think of these modes as defining the scope of a git reset opera
 To just undo any uncommitted changes:
 
 ~~~
+git status
+git add c.txt
+git status
 git reset HEAD
+git status
 ~~~
 {: .language-bash}
+
+You can add and commit the changes or restore the file.
 
 `git reset` can also work on a single file:
 
@@ -58,23 +109,6 @@ git reset HEAD
 git reset HEAD~2 foo.txt
 ~~~
 {: .language-bash}
-
-
-## Git Revert
-
-Reverting undoes a commit by creating a new commit. This is a safe way to undo changes, as it has no chance of re-writing the commit history. For example, the following command will figure out the changes contained in the 2nd to last commit, create a new commit undoing those changes, and tack the new commit onto the existing project.
-
-~~~
-git checkout hotfix
-git revert HEAD~2
-~~~
-{: .language-bash}
-
-![GitFlow 1](../fig/08-revert.png)
-
-Note that revert only backs out the atomic changes of the specific commit (by default, you can also give it a range of commits but we are not going to do that here, see the help).
-
-`git revert` does not rewrite history which is why it is the preferred way of dealing with issues when the changes have already been pushed to a remote repository.
 
 ## Git Checkout: A Gentle Way
 
@@ -88,8 +122,40 @@ git checkout HEAD~2
 
 ![GitFlow 1](../fig/09-checkout.png)
 
+This puts you in a detached HEAD state. AGHRRR!
+
+Most of the time, HEAD points to a branch name. When you add a new commit, your branch reference is updated to point to it, but HEAD remains the same. When you change branches, HEAD is updated to point to the branch you’ve switched to. All of that means that, in these scenarios, HEAD is synonymous with “the last commit in the current branch.” This is the normal state, in which HEAD is attached to a branch.
+
+The detached HEAD state is when HEAD is pointing directly to a commit instead of a branch. This is really useful because it allows you to go to a previous point in the project’s history. You can also make changes here and see how they affect the project.
+
+~~~
+echo "Welcome to the alternate timeline, Morty!" > new-file.txt
+git add .
+git commit -m "Create new file"
+echo "Another line" >> new-file.txt
+git commit -a -m "Add a new line to the file"
+git log --oneline
+~~~
+{: .language-bash}
+
+If you haven't made any changes or you have made changes but you want to discard them you can recover by switching back to your branch:
+
+~~~
+git checkout hotfix
+~~~
+{: .language-bash}
+
+Alternatively, you want to keep the changes:
+
+~~~
+git branch alt-history
+git checkout alt-history
+~~~
+{: .language-bash}
+
 
 https://www.atlassian.com/git/tutorials/resetting-checking-out-and-reverting
+Also OMG: http://blog.kfish.org/2010/04/git-lola.html
 
 ## Exercise: Undoing Changes
 
@@ -153,3 +219,5 @@ https://www.atlassian.com/git/tutorials/resetting-checking-out-and-reverting
 <!--- ![GitFlow 1](../fig/43-undo.png) --->
 
 {% include links.md %}
+
+

--- a/_episodes/05-merging.md
+++ b/_episodes/05-merging.md
@@ -15,12 +15,11 @@ Even if you live well, one day you will have to merge a branch. Your branch may 
 
 There are 3 ways to merge:
 
+- non-fast-forward merged (recommended)
+
 - fast forward merged
 
-- non-fast-forward merged
-
 - three way
-
 
 Reminder: when starting work on a new feature, be careful where you branch from!
 
@@ -33,6 +32,17 @@ git checkout -b develop upstream/develop
 
 ![Merging 1](../fig/09-merging.png)
 
+## Non-fast-forwad Merge
+
+Merges branch by creating a merge commit. Prompts for merge commit message. Ideal for merging two branches.
+
+~~~
+git checkout main
+git merge --no-ff <branch>
+~~~
+{: .language-bash}
+
+The `--no-ff` flag causes the merge to always create a new commit object, even if the merge could be performed with a fast-forward. This avoids losing information about the historical existence of a feature branch and groups together all commits that together added the feature.
 
 ## Fast-forward Merger
 
@@ -46,18 +56,6 @@ git merge --ff-only <branch>
 {: .language-bash}
 
 Using the fast-forward merge it is impossible to see from the `git` history which of the commit objects together have implemented a feature. You would have to manually read all the log messages. Reverting a whole feature (i.e. a group of commits), is a true headache in the latter situation, whereas it is easily done if the --no-ff flag was used.
-
-## Non-fast-forwad Merge
-
-Merges branch by creating a merge commit. Prompts for merge commit message. Ideal for merging two branches.
-
-~~~
-git checkout main
-git merge --no-ff <branch>
-~~~
-{: .language-bash}
-
-The `--no-ff` flag causes the merge to always create a new commit object, even if the merge could be performed with a fast-forward. This avoids losing information about the historical existence of a feature branch and groups together all commits that together added the feature.
 
 ### Three-way Merger
 

--- a/_episodes/05-merging.md
+++ b/_episodes/05-merging.md
@@ -38,7 +38,7 @@ Merges branch by creating a merge commit. Prompts for merge commit message. Idea
 
 ~~~
 git checkout main
-git merge --no-ff <branch>
+git merge --no-ff <branch> -m "Message"
 ~~~
 {: .language-bash}
 
@@ -56,6 +56,8 @@ git merge --ff-only <branch>
 {: .language-bash}
 
 Using the fast-forward merge it is impossible to see from the `git` history which of the commit objects together have implemented a feature. You would have to manually read all the log messages. Reverting a whole feature (i.e. a group of commits), is a true headache in the latter situation, whereas it is easily done if the --no-ff flag was used.
+
+For a good illustration of fast-forward merger (and other concepts), see this thread: https://stackoverflow.com/questions/9069061/what-effect-does-the-no-ff-flag-have-for-git-merge
 
 ### Three-way Merger
 

--- a/_episodes/08-gitflow.md
+++ b/_episodes/08-gitflow.md
@@ -59,6 +59,7 @@ Indeed, due to GitFlow’s complexity, it could slow down the development proces
 >
 > > ## Solution
 > > ~~~
+> > git fetch upstream
 > > git checkout -b myfeature upstream/develop
 > > ~~~
 > > {: .language-bash}

--- a/_episodes/09-forking.md
+++ b/_episodes/09-forking.md
@@ -10,6 +10,7 @@ keypoints:
 - "First key point. Brief Answer to questions. (FIXME)"
 ---
 
+Make sure that the main is clean, everything is committed.
 
 ![GitFlow 1](../fig/27-forking-1.png)
 ![GitFlow 1](../fig/28-forking-2.png)


### PR DESCRIPTION
Fixing the following issues:

 Switch revert and reset, the recommended method should be first
 Git revert exercise is all wrong
 Add image for the FF merge, the figures here are
 Move the no-ff merge method first, the recommended method should be first
 no-ff merge should have -m "Message"
 GitFlow exercise 1: upstream main?
 GitFlow exercise 2: make dev branch, id does not exist
 make sure that main is clean before the forking lesson
